### PR TITLE
Update minimum storage

### DIFF
--- a/docs/developers/build.md
+++ b/docs/developers/build.md
@@ -11,7 +11,7 @@ You can build ProtonAOSP yourself, whether it's for adding changes to an officia
 You'll need a reasonably capable computer to avoid running into issues:
 
 - 16+ GB of RAM
-- 200+ GB of free SSD storage
+- 400+ GB of free SSD storage
 
 ## Prepare your system
 


### PR DESCRIPTION
Building on a public cloud with a 200 GB disk failed with No space left on device.
https://source.android.com/setup/build/requirements they recommend 250 GB + 150 GB = 400 GB